### PR TITLE
Update devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
     "name": ".NET in Codespaces",
-    "image": "mcr.microsoft.com/dotnet/sdk:8.0-preview",
+    "image": "mcr.microsoft.com/dotnet/sdk:8.0",
     "features": {
         "ghcr.io/devcontainers/features/docker-in-docker:2": {},
         "ghcr.io/devcontainers/features/github-cli:1": {
@@ -12,7 +12,12 @@
         "ghcr.io/azure/azure-dev/azd:0": {
             "version": "latest"
         },
-        "ghcr.io/devcontainers/features/common-utils:2": {}
+        "ghcr.io/devcontainers/features/common-utils:2": {},
+        "ghcr.io/devcontainers/features/dotnet:2": {
+            "version": "none",
+            "dotnetRuntimeVersions": "7.0",
+            "aspNetCoreRuntimeVersions": "7.0"
+        }
     },
     "customizations": {
         "vscode": {


### PR DESCRIPTION
This fixes #1 and fixes #2 by doing the following:

- Fix #1 Removes the `-preview` tag for the image, using the base `8.0` tagged image which carries forward better updates beyond preview
- Fix #2 by adding the runtimes for 7.0 into the image to help with the VSCode extension not needing to acquire them post image/project load, thus optimizing the start of the extension.