### PR TITLE
Fixing C# extension tool name

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -27,7 +27,7 @@
                 "GitHub.vscode-github-actions",
                 "ms-dotnettools.vscode-dotnet-runtime",
                 "ms-dotnettools.csdevkit",
-                "ms-dotnetools.csharp"
+                "ms-dotnettools.csharp"
             ]
         }
     },


### PR DESCRIPTION
Changed the name of the csharp extension to the correct one.